### PR TITLE
style: dashboard mobile support

### DIFF
--- a/app/(dashboard)/layout.tsx
+++ b/app/(dashboard)/layout.tsx
@@ -7,7 +7,7 @@ export default function DashboardLayout({
   children: React.ReactNode
 }) {
   return (
-    <div className="relative h-screen w-screen sm:grid sm:grid-cols-12">
+    <div className="relative h-screen w-screen overflow-hidden sm:grid sm:grid-cols-12">
       <div className="absolute top-0 w-full">
         <DashboardHeader />
       </div>

--- a/app/(dashboard)/layout.tsx
+++ b/app/(dashboard)/layout.tsx
@@ -7,15 +7,15 @@ export default function DashboardLayout({
   children: React.ReactNode
 }) {
   return (
-    <div className="relative grid h-screen w-screen grid-cols-12">
+    <div className="relative h-screen w-screen sm:grid sm:grid-cols-12">
       <div className="absolute top-0 w-full">
         <DashboardHeader />
       </div>
-      <div className="col-span-3">
+      <div className="hidden sm:col-span-3 sm:block">
         <Sidebar />
       </div>
-      <div className="col-span-9 bg-gray-100">
-        <div className="px-10 pt-24">{children}</div>
+      <div className="bg-gray-100 sm:col-span-9">
+        <div className="px-4 pt-28 sm:px-10 sm:pt-24">{children}</div>
       </div>
     </div>
   )

--- a/app/(dashboard)/layout.tsx
+++ b/app/(dashboard)/layout.tsx
@@ -15,7 +15,7 @@ export default function DashboardLayout({
         <Sidebar />
       </div>
       <div className="bg-gray-100 sm:col-span-9">
-        <div className="px-4 pt-28 sm:px-10 sm:pt-24">{children}</div>
+        <div className="px-4 pt-24 sm:px-10">{children}</div>
       </div>
     </div>
   )

--- a/app/(dashboard)/myEvents/page.tsx
+++ b/app/(dashboard)/myEvents/page.tsx
@@ -24,6 +24,7 @@ export default function MyEvents() {
   const [tabQuery, setTabQuery] = useState('')
   const [searchInput, setSearchInput] = useState('')
   const eventsEndpt = `/api/event?hostId=${userId}`
+  const rows = window.innerWidth >= 640 ? 5 : 3
 
   async function loadEvents(apiEndpoint: string) {
     try {
@@ -41,11 +42,11 @@ export default function MyEvents() {
   }
 
   useEffect(() => {
-    let endpt = eventsEndpt
+    let endpt = eventsEndpt + `&take=${rows}`
     if (tabQuery) endpt += `&tab=${tabQuery}`
     if (searchInput) endpt += `&search=${searchInput}`
-    if (tableSkips > 0) endpt += `&skip=${tableSkips * 5}`
-    console.log('table skips:', tableSkips, tableSkips * 5)
+    if (tableSkips > 0) endpt += `&skip=${tableSkips * rows}`
+    console.log('table skips:', tableSkips, tableSkips * rows)
     loadEvents(endpt)
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [tabQuery, searchInput, eventsEndpt, tableSkips])
@@ -64,7 +65,10 @@ export default function MyEvents() {
         events={events}
         eventsAreLoading={eventsAreLoading}
         reload={() => loadEvents(eventsEndpt)}
+        rows={rows}
       />
+
+      {/* table skip button */}
       <div className="flex justify-center sm:justify-end">
         <div className="relative flex w-full space-x-4 rounded-full bg-gray-200 px-4 py-2.5 sm:w-56 sm:justify-between">
           <div className="flex place-items-center justify-center space-x-2">
@@ -85,12 +89,12 @@ export default function MyEvents() {
             <button
               className="absolute right-3 rounded-full p-1 transition-colors duration-150 hover:bg-gray-300 disabled:cursor-default disabled:hover:bg-gray-200 sm:static"
               onClick={() => setTableSkips(tableSkips + 1)}
-              disabled={(tableSkips + 1) * 5 >= allEventsCount}
+              disabled={(tableSkips + 1) * rows >= allEventsCount}
             >
               <ArrowRightIcon
                 className={classNames(
                   'h-5 w-5',
-                  (tableSkips + 1) * 5 >= allEventsCount
+                  (tableSkips + 1) * rows >= allEventsCount
                     ? 'text-gray-400 text-opacity-50'
                     : 'text-gray-600'
                 )}
@@ -100,9 +104,9 @@ export default function MyEvents() {
           <div className="flex w-full justify-center space-x-2 sm:justify-end">
             <p className="font-medium text-gray-600">
               {events.length > 0
-                ? `${tableSkips * 5 + 1} - ${
-                    tableSkips * 5 + 5 <= allEventsCount
-                      ? tableSkips * 5 + 5
+                ? `${tableSkips * rows + 1} - ${
+                    tableSkips * rows + rows <= allEventsCount
+                      ? tableSkips * rows + rows
                       : allEventsCount
                   }`
                 : '0 - 0'}

--- a/app/(dashboard)/myEvents/page.tsx
+++ b/app/(dashboard)/myEvents/page.tsx
@@ -52,11 +52,11 @@ export default function MyEvents() {
 
   return (
     <PageWrapper title="My Events" description="View and manage your events">
-      <div className="flex space-x-6">
-        <div className="w-1/2">
+      <div className="sm:flex sm:space-x-6">
+        <div className="w-full sm:w-1/2">
           <EventTableTabs setTabQuery={setTabQuery} />
         </div>
-        <div className="w-1/2">
+        <div className="w-full pt-4 sm:w-1/2 sm:pt-0">
           <SearchBar setSearchInput={setSearchInput} />
         </div>
       </div>
@@ -65,11 +65,11 @@ export default function MyEvents() {
         eventsAreLoading={eventsAreLoading}
         reload={() => loadEvents(eventsEndpt)}
       />
-      <div className="flex justify-end">
-        <div className="flex w-56 justify-between space-x-4 rounded-full bg-gray-200 px-4 py-2.5">
+      <div className="flex justify-center sm:justify-end">
+        <div className="relative flex w-full space-x-4 rounded-full bg-gray-200 px-4 py-2.5 sm:w-56 sm:justify-between">
           <div className="flex place-items-center justify-center space-x-2">
             <button
-              className="cursor-pointer rounded-full p-1 transition-colors duration-150 hover:bg-gray-300 disabled:cursor-default disabled:hover:bg-gray-200"
+              className="absolute left-3 cursor-pointer rounded-full p-1 transition-colors duration-150 hover:bg-gray-300 disabled:cursor-default disabled:hover:bg-gray-200 sm:static"
               onClick={() => setTableSkips(tableSkips - 1)}
               disabled={tableSkips === 0}
             >
@@ -83,7 +83,7 @@ export default function MyEvents() {
               />
             </button>
             <button
-              className="rounded-full p-1 transition-colors duration-150 hover:bg-gray-300 disabled:cursor-default disabled:hover:bg-gray-200"
+              className="absolute right-3 rounded-full p-1 transition-colors duration-150 hover:bg-gray-300 disabled:cursor-default disabled:hover:bg-gray-200 sm:static"
               onClick={() => setTableSkips(tableSkips + 1)}
               disabled={(tableSkips + 1) * 5 >= allEventsCount}
             >
@@ -97,16 +97,18 @@ export default function MyEvents() {
               />
             </button>
           </div>
-          <p className="font-medium text-gray-600">
-            {events.length > 0
-              ? `${tableSkips * 5 + 1} - ${
-                  tableSkips * 5 + 5 <= allEventsCount
-                    ? tableSkips * 5 + 5
-                    : allEventsCount
-                }`
-              : '0 - 0'}
-          </p>
-          <p className="font-medium text-gray-600">{`/ ${allEventsCount}`}</p>
+          <div className="flex w-full justify-center space-x-2 sm:justify-end">
+            <p className="font-medium text-gray-600">
+              {events.length > 0
+                ? `${tableSkips * 5 + 1} - ${
+                    tableSkips * 5 + 5 <= allEventsCount
+                      ? tableSkips * 5 + 5
+                      : allEventsCount
+                  }`
+                : '0 - 0'}
+            </p>
+            <p className="font-medium text-gray-600">{`/ ${allEventsCount}`}</p>
+          </div>
         </div>
       </div>
     </PageWrapper>

--- a/app/(guest)/layout.tsx
+++ b/app/(guest)/layout.tsx
@@ -6,8 +6,8 @@ export default function GuestLayout({
   children: React.ReactNode
 }) {
   return (
-    <div className="relative h-screen w-screen">
-      <div className="absolute top-0 w-full">
+    <div className="relative h-screen w-screen overflow-hidden">
+      <div className="fixed top-0 w-full">
         <GuestHeader />
       </div>
       <div className="h-full bg-gray-100 px-10 pt-24">{children}</div>

--- a/app/api/event/route.tsx
+++ b/app/api/event/route.tsx
@@ -11,6 +11,7 @@ export async function GET(req: NextRequest) {
     tab: req.nextUrl.searchParams.get('tab'),
     search: req.nextUrl.searchParams.get('search'),
     skip: req.nextUrl.searchParams.get('skip'),
+    take: req.nextUrl.searchParams.get('take'),
   }
   console.log('query:', query)
 
@@ -88,7 +89,7 @@ export async function GET(req: NextRequest) {
           },
         },
         skip: query.skip ? Number(query.skip) : 0,
-        take: 5,
+        take: Number(query.take),
         orderBy: { createdAt: 'desc' },
       })
 
@@ -112,7 +113,7 @@ export async function GET(req: NextRequest) {
           },
         },
         skip: query.skip ? Number(query.skip) : 0,
-        take: 5,
+        take: Number(query.take),
         orderBy: { createdAt: 'desc' },
       })
 

--- a/components/Event/EventForm.tsx
+++ b/components/Event/EventForm.tsx
@@ -142,7 +142,7 @@ export default function EventForm({ userId }: { userId: string | null }) {
           </div>
 
           <div className="flex w-full space-x-2">
-            <div className="relative w-1/2">
+            <div className="relative w-1/3">
               <label
                 htmlFor="access-date"
                 className="absolute left-4 top-3 text-xs font-bold uppercase text-gray-600"
@@ -159,7 +159,7 @@ export default function EventForm({ userId }: { userId: string | null }) {
                 onChange={(ev) => setTempAccessDate(ev.target.value)}
               />
             </div>
-            <div className="relative w-1/2">
+            <div className="relative w-1/3">
               <label
                 htmlFor="access-start"
                 className="absolute left-4 top-3 text-xs font-bold uppercase text-gray-600"
@@ -176,7 +176,7 @@ export default function EventForm({ userId }: { userId: string | null }) {
                 onChange={(ev) => setTempAccessStart(ev.target.value)}
               />
             </div>
-            <div className="relative w-1/2">
+            <div className="relative w-1/3">
               <label
                 htmlFor="access-end"
                 className="absolute left-4 top-3 text-xs font-bold uppercase text-gray-600"

--- a/components/Event/EventForm.tsx
+++ b/components/Event/EventForm.tsx
@@ -151,7 +151,7 @@ export default function EventForm({ userId }: { userId: string | null }) {
                 <p className="block sm:hidden">Date</p>
               </label>
               <input
-                className="h-16 w-full cursor-pointer appearance-none rounded-md border px-3 pt-6 text-sm text-gray-800 sm:text-base"
+                className="h-16 w-full cursor-pointer appearance-none rounded-md border bg-white px-3 pt-6 text-left text-sm text-gray-800 sm:text-base"
                 type="date"
                 id="access-date"
                 value={tempAccessDate}
@@ -168,7 +168,7 @@ export default function EventForm({ userId }: { userId: string | null }) {
                 <p className="block sm:hidden">Starts</p>
               </label>
               <input
-                className="h-16 w-full cursor-pointer appearance-none rounded-md border px-3 pt-6 text-sm text-gray-800 sm:text-base"
+                className="h-16 w-full cursor-pointer appearance-none rounded-md border bg-white px-3 pt-6 text-left text-sm text-gray-800 sm:text-base"
                 type="time"
                 id="access-start"
                 value={tempAccessStart}
@@ -185,7 +185,7 @@ export default function EventForm({ userId }: { userId: string | null }) {
                 <p className="block sm:hidden">Expires</p>
               </label>
               <input
-                className="h-16 w-full cursor-pointer appearance-none rounded-md border px-3 pt-6 text-sm text-gray-800 sm:text-base"
+                className="h-16 w-full cursor-pointer appearance-none rounded-md border bg-white px-3 pt-6 text-left text-sm text-gray-800 sm:text-base"
                 type="time"
                 id="access-end"
                 value={tempAccessEnd}

--- a/components/Event/EventForm.tsx
+++ b/components/Event/EventForm.tsx
@@ -151,7 +151,7 @@ export default function EventForm({ userId }: { userId: string | null }) {
                 <p className="block sm:hidden">Date</p>
               </label>
               <input
-                className="flex h-16 w-full cursor-pointer appearance-none justify-start rounded-md border bg-white px-3 pt-6 text-sm text-gray-800 sm:text-base"
+                className="h-16 w-full cursor-pointer appearance-none rounded-md border bg-white px-3 pt-6 text-sm text-gray-800 sm:text-base"
                 type="date"
                 id="access-date"
                 value={tempAccessDate}
@@ -168,7 +168,7 @@ export default function EventForm({ userId }: { userId: string | null }) {
                 <p className="block sm:hidden">Starts</p>
               </label>
               <input
-                className="flex h-16 w-full cursor-pointer appearance-none justify-start rounded-md border bg-white px-3 pt-6 text-sm text-gray-800 sm:text-base"
+                className="h-16 w-full cursor-pointer appearance-none rounded-md border bg-white px-3 pt-6 text-sm text-gray-800 sm:text-base"
                 type="time"
                 id="access-start"
                 value={tempAccessStart}
@@ -185,7 +185,7 @@ export default function EventForm({ userId }: { userId: string | null }) {
                 <p className="block sm:hidden">Expires</p>
               </label>
               <input
-                className="flex h-16 w-full cursor-pointer appearance-none justify-start rounded-md border bg-white px-3 pt-6 text-sm text-gray-800 sm:text-base"
+                className="h-16 w-full cursor-pointer appearance-none rounded-md border bg-white px-3 pt-6 text-sm text-gray-800 sm:text-base"
                 type="time"
                 id="access-end"
                 value={tempAccessEnd}

--- a/components/Event/EventForm.tsx
+++ b/components/Event/EventForm.tsx
@@ -151,7 +151,7 @@ export default function EventForm({ userId }: { userId: string | null }) {
                 <p className="block sm:hidden">Date</p>
               </label>
               <input
-                className="block h-16 w-full cursor-pointer appearance-none rounded-md border bg-white px-3 pt-6 text-left text-sm text-gray-800 sm:text-base"
+                className="flex h-16 w-full cursor-pointer appearance-none justify-start rounded-md border bg-white px-3 pt-6 text-sm text-gray-800 sm:text-base"
                 type="date"
                 id="access-date"
                 value={tempAccessDate}
@@ -168,7 +168,7 @@ export default function EventForm({ userId }: { userId: string | null }) {
                 <p className="block sm:hidden">Starts</p>
               </label>
               <input
-                className="block h-16 w-full cursor-pointer appearance-none rounded-md border bg-white px-3 pt-6 text-left text-sm text-gray-800 sm:text-base"
+                className="flex h-16 w-full cursor-pointer appearance-none justify-start rounded-md border bg-white px-3 pt-6 text-sm text-gray-800 sm:text-base"
                 type="time"
                 id="access-start"
                 value={tempAccessStart}
@@ -185,7 +185,7 @@ export default function EventForm({ userId }: { userId: string | null }) {
                 <p className="block sm:hidden">Expires</p>
               </label>
               <input
-                className="block h-16 w-full cursor-pointer appearance-none rounded-md border bg-white px-3 pt-6 text-left text-sm text-gray-800 sm:text-base"
+                className="flex h-16 w-full cursor-pointer appearance-none justify-start rounded-md border bg-white px-3 pt-6 text-sm text-gray-800 sm:text-base"
                 type="time"
                 id="access-end"
                 value={tempAccessEnd}

--- a/components/Event/EventForm.tsx
+++ b/components/Event/EventForm.tsx
@@ -151,7 +151,7 @@ export default function EventForm({ userId }: { userId: string | null }) {
                 <p className="block sm:hidden">Date</p>
               </label>
               <input
-                className="h-16 w-full cursor-pointer appearance-none rounded-md border bg-white px-3 pt-6 text-left text-sm text-gray-800 sm:text-base"
+                className="text block h-16 w-full cursor-pointer appearance-none rounded-md border bg-white px-3 pt-6  text-sm text-gray-800 sm:text-base"
                 type="date"
                 id="access-date"
                 value={tempAccessDate}
@@ -168,7 +168,7 @@ export default function EventForm({ userId }: { userId: string | null }) {
                 <p className="block sm:hidden">Starts</p>
               </label>
               <input
-                className="h-16 w-full cursor-pointer appearance-none rounded-md border bg-white px-3 pt-6 text-left text-sm text-gray-800 sm:text-base"
+                className="block h-16 w-full cursor-pointer appearance-none rounded-md border bg-white px-3 pt-6 text-left text-sm text-gray-800 sm:text-base"
                 type="time"
                 id="access-start"
                 value={tempAccessStart}
@@ -185,7 +185,7 @@ export default function EventForm({ userId }: { userId: string | null }) {
                 <p className="block sm:hidden">Expires</p>
               </label>
               <input
-                className="h-16 w-full cursor-pointer appearance-none rounded-md border bg-white px-3 pt-6 text-left text-sm text-gray-800 sm:text-base"
+                className="text block h-16 w-full cursor-pointer appearance-none rounded-md border bg-white px-3 pt-6  text-sm text-gray-800 sm:text-base"
                 type="time"
                 id="access-end"
                 value={tempAccessEnd}

--- a/components/Event/EventForm.tsx
+++ b/components/Event/EventForm.tsx
@@ -141,8 +141,8 @@ export default function EventForm({ userId }: { userId: string | null }) {
             />
           </div>
 
-          <div className="flex w-full space-x-2">
-            <div className="relative w-1/3">
+          <div className="space-y-2 sm:flex sm:w-full sm:space-x-2 sm:space-y-0">
+            <div className="relative sm:w-1/3">
               <label
                 htmlFor="access-date"
                 className="absolute left-4 top-3 text-xs font-bold uppercase text-gray-600"
@@ -159,7 +159,7 @@ export default function EventForm({ userId }: { userId: string | null }) {
                 onChange={(ev) => setTempAccessDate(ev.target.value)}
               />
             </div>
-            <div className="relative w-1/3">
+            <div className="relative sm:w-1/3">
               <label
                 htmlFor="access-start"
                 className="absolute left-4 top-3 text-xs font-bold uppercase text-gray-600"
@@ -176,7 +176,7 @@ export default function EventForm({ userId }: { userId: string | null }) {
                 onChange={(ev) => setTempAccessStart(ev.target.value)}
               />
             </div>
-            <div className="relative w-1/3">
+            <div className="relative sm:w-1/3">
               <label
                 htmlFor="access-end"
                 className="absolute left-4 top-3 text-xs font-bold uppercase text-gray-600"

--- a/components/Event/EventForm.tsx
+++ b/components/Event/EventForm.tsx
@@ -77,7 +77,7 @@ export default function EventForm({ userId }: { userId: string | null }) {
               Title
             </label>
             <input
-              className="h-16 w-full rounded-md border px-4 pt-6 text-gray-800"
+              className="h-16 w-full rounded-md border px-4 pt-6 text-sm text-gray-800 sm:text-base"
               type="text"
               id="title"
               placeholder="My title"
@@ -96,12 +96,12 @@ export default function EventForm({ userId }: { userId: string | null }) {
           <div className="relative">
             <label
               htmlFor="description"
-              className="absolute left-[0.6rem] top-3 rounded-xl bg-opacity-50 px-2 text-xs font-bold uppercase text-gray-600 backdrop-blur-md"
+              className="absolute left-[0.6rem] top-3 rounded-xl bg-opacity-50 px-2 text-xs font-bold uppercase text-gray-600 backdrop-blur-sm"
             >
               Description
             </label>
             <textarea
-              className="h-32 w-full rounded-md border px-4 pt-8 text-gray-800"
+              className="h-32 w-full rounded-md border px-4 pt-8 text-sm text-gray-800 sm:text-base"
               id="description"
               placeholder="My description"
               maxLength={descMaxLength}
@@ -112,7 +112,7 @@ export default function EventForm({ userId }: { userId: string | null }) {
               value={tempDesc}
               onChange={(ev) => setTempDesc(ev.target.value)}
             />
-            <p className="absolute bottom-3 right-3 text-sm text-gray-500">
+            <p className="absolute bottom-3 right-3 rounded-full p-1 text-sm text-gray-500 backdrop-blur-sm">
               {descMaxLength - tempDesc.length} characters left
             </p>
           </div>
@@ -125,7 +125,7 @@ export default function EventForm({ userId }: { userId: string | null }) {
               Location
             </label>
             <input
-              className="h-16 w-full rounded-md border px-4 pt-6 text-gray-800"
+              className="h-16 w-full rounded-md border px-4 pt-6 text-sm text-gray-800 sm:text-base"
               type="text"
               id="location"
               placeholder="My location"
@@ -147,10 +147,11 @@ export default function EventForm({ userId }: { userId: string | null }) {
                 htmlFor="access-date"
                 className="absolute left-4 top-3 text-xs font-bold uppercase text-gray-600"
               >
-                Access Date
+                <p className="hidden sm:block">Access Date</p>
+                <p className="block sm:hidden">Date</p>
               </label>
               <input
-                className="h-16 w-full cursor-pointer rounded-md border px-3 pt-6 text-gray-600"
+                className="h-16 w-full cursor-pointer rounded-md border px-3 pt-6 text-sm text-gray-800 sm:text-base"
                 type="date"
                 id="access-date"
                 value={tempAccessDate}
@@ -163,10 +164,11 @@ export default function EventForm({ userId }: { userId: string | null }) {
                 htmlFor="access-start"
                 className="absolute left-4 top-3 text-xs font-bold uppercase text-gray-600"
               >
-                Access Starts
+                <p className="hidden sm:block">Access Starts</p>
+                <p className="block sm:hidden">Starts</p>
               </label>
               <input
-                className="h-16 w-full cursor-pointer rounded-md border px-3 pt-6 text-gray-600"
+                className="h-16 w-full cursor-pointer rounded-md border px-3 pt-6 text-sm text-gray-800 sm:text-base"
                 type="time"
                 id="access-start"
                 value={tempAccessStart}
@@ -179,10 +181,11 @@ export default function EventForm({ userId }: { userId: string | null }) {
                 htmlFor="access-end"
                 className="absolute left-4 top-3 text-xs font-bold uppercase text-gray-600"
               >
-                Access Expires
+                <p className="hidden sm:block">Access Expires</p>
+                <p className="block sm:hidden">Expires</p>
               </label>
               <input
-                className="h-16 w-full cursor-pointer rounded-md border px-3 pt-6 text-gray-800"
+                className="h-16 w-full cursor-pointer rounded-md border px-3 pt-6 text-sm text-gray-800 sm:text-base"
                 type="time"
                 id="access-end"
                 value={tempAccessEnd}

--- a/components/Event/EventForm.tsx
+++ b/components/Event/EventForm.tsx
@@ -151,7 +151,7 @@ export default function EventForm({ userId }: { userId: string | null }) {
                 <p className="block sm:hidden">Date</p>
               </label>
               <input
-                className="h-16 w-full cursor-pointer rounded-md border px-3 pt-6 text-sm text-gray-800 sm:text-base"
+                className="h-16 w-full cursor-pointer appearance-none rounded-md border px-3 pt-6 text-sm text-gray-800 sm:text-base"
                 type="date"
                 id="access-date"
                 value={tempAccessDate}
@@ -168,7 +168,7 @@ export default function EventForm({ userId }: { userId: string | null }) {
                 <p className="block sm:hidden">Starts</p>
               </label>
               <input
-                className="h-16 w-full cursor-pointer rounded-md border px-3 pt-6 text-sm text-gray-800 sm:text-base"
+                className="h-16 w-full cursor-pointer appearance-none rounded-md border px-3 pt-6 text-sm text-gray-800 sm:text-base"
                 type="time"
                 id="access-start"
                 value={tempAccessStart}
@@ -185,7 +185,7 @@ export default function EventForm({ userId }: { userId: string | null }) {
                 <p className="block sm:hidden">Expires</p>
               </label>
               <input
-                className="h-16 w-full cursor-pointer rounded-md border px-3 pt-6 text-sm text-gray-800 sm:text-base"
+                className="h-16 w-full cursor-pointer appearance-none rounded-md border px-3 pt-6 text-sm text-gray-800 sm:text-base"
                 type="time"
                 id="access-end"
                 value={tempAccessEnd}

--- a/components/Event/EventForm.tsx
+++ b/components/Event/EventForm.tsx
@@ -151,7 +151,7 @@ export default function EventForm({ userId }: { userId: string | null }) {
                 <p className="block sm:hidden">Date</p>
               </label>
               <input
-                className="text block h-16 w-full cursor-pointer appearance-none rounded-md border bg-white px-3 pt-6  text-sm text-gray-800 sm:text-base"
+                className="block h-16 w-full cursor-pointer appearance-none rounded-md border bg-white px-3 pt-6 text-left text-sm text-gray-800 sm:text-base"
                 type="date"
                 id="access-date"
                 value={tempAccessDate}
@@ -185,7 +185,7 @@ export default function EventForm({ userId }: { userId: string | null }) {
                 <p className="block sm:hidden">Expires</p>
               </label>
               <input
-                className="text block h-16 w-full cursor-pointer appearance-none rounded-md border bg-white px-3 pt-6  text-sm text-gray-800 sm:text-base"
+                className="block h-16 w-full cursor-pointer appearance-none rounded-md border bg-white px-3 pt-6 text-left text-sm text-gray-800 sm:text-base"
                 type="time"
                 id="access-end"
                 value={tempAccessEnd}

--- a/components/Event/EventModal/DeleteView.tsx
+++ b/components/Event/EventModal/DeleteView.tsx
@@ -71,7 +71,7 @@ export default function DeleteView({
         </div>
         {displayInvites.length > 0 && (
           <div className="pt-6">
-            <p className="px-32 pb-1 text-center text-gray-600">
+            <p className="pb-2 text-center text-gray-600 sm:px-32">
               Please provide a reason for canceling. All guests will be
               notified.
             </p>
@@ -84,7 +84,7 @@ export default function DeleteView({
                 value={reason}
                 onChange={(ev) => setReason(ev.target.value)}
               />
-              <p className="absolute bottom-3 right-3 text-sm text-gray-500">
+              <p className="absolute bottom-3 right-3 rounded-full p-1 text-sm text-gray-500 backdrop-blur-sm">
                 {cancelReasonMaxLength - reason.length} characters left
               </p>
             </div>

--- a/components/Event/EventModal/DeleteView.tsx
+++ b/components/Event/EventModal/DeleteView.tsx
@@ -64,7 +64,7 @@ export default function DeleteView({
 
   return (
     <>
-      <div className="relative px-7 py-6">
+      <div className="relative p-4 sm:px-7 sm:py-6">
         <div className="flex justify-center space-x-1 pt-4">
           <p className="text-gray-600">Cancel</p>
           <p className="font-medium text-gray-900">{`"${event.title}"?`}</p>

--- a/components/Event/EventModal/EditView.tsx
+++ b/components/Event/EventModal/EditView.tsx
@@ -237,8 +237,8 @@ export default function EditView({
               />
             </div>
 
-            <div className="flex w-full space-x-2">
-              <div className="relative w-1/3">
+            <div className="space-y-2 sm:flex sm:w-full sm:space-x-2 sm:space-y-0">
+              <div className="relative sm:w-1/3">
                 <label
                   htmlFor="access-date"
                   className="absolute left-4 top-3 text-xs font-bold uppercase text-gray-600"
@@ -255,7 +255,7 @@ export default function EditView({
                   onChange={(ev) => setTempAccessDate(ev.target.value)}
                 />
               </div>
-              <div className="relative w-1/3">
+              <div className="relative sm:w-1/3">
                 <label
                   htmlFor="access-start"
                   className="absolute left-4 top-3 text-xs font-bold uppercase text-gray-600"
@@ -272,7 +272,7 @@ export default function EditView({
                   onChange={(ev) => setTempAccessStart(ev.target.value)}
                 />
               </div>
-              <div className="relative w-1/3">
+              <div className="relative sm:w-1/3">
                 <label
                   htmlFor="access-end"
                   className="absolute left-4 top-3 text-xs font-bold uppercase text-gray-600"

--- a/components/Event/EventModal/EditView.tsx
+++ b/components/Event/EventModal/EditView.tsx
@@ -247,7 +247,7 @@ export default function EditView({
                   <p className="block sm:hidden">Date</p>
                 </label>
                 <input
-                  className="h-16 w-full cursor-pointer rounded-md border px-3 pt-6 text-sm text-gray-600 sm:text-base"
+                  className="h-16 w-full cursor-pointer appearance-none rounded-md border bg-white px-3 pt-6 text-sm text-gray-600 sm:text-base"
                   type="date"
                   id="access-date"
                   value={tempAccessDate}
@@ -264,7 +264,7 @@ export default function EditView({
                   <p className="block sm:hidden">Starts</p>
                 </label>
                 <input
-                  className="h-16 w-full cursor-pointer rounded-md border px-3 pt-6 text-sm text-gray-600 sm:text-base"
+                  className="h-16 w-full cursor-pointer appearance-none rounded-md border bg-white px-3 pt-6 text-sm text-gray-600 sm:text-base"
                   type="time"
                   id="access-start"
                   value={tempAccessStart}
@@ -281,7 +281,7 @@ export default function EditView({
                   <p className="block sm:hidden">Expires</p>
                 </label>
                 <input
-                  className="h-16 w-full cursor-pointer rounded-md border px-3 pt-6 text-sm text-gray-800 sm:text-base"
+                  className="h-16 w-full cursor-pointer appearance-none rounded-md border bg-white px-3 pt-6 text-sm text-gray-800 sm:text-base"
                   type="time"
                   id="access-end"
                   value={tempAccessEnd}

--- a/components/Event/EventModal/EditView.tsx
+++ b/components/Event/EventModal/EditView.tsx
@@ -159,7 +159,7 @@ export default function EditView({
           editEvent(data)
         })}
       >
-        <div className="px-7 pb-6 pt-12">
+        <div className="p-4 pt-8 sm:px-7 sm:pb-6 sm:pt-12">
           <h1 className="flex justify-center pb-3 text-lg font-medium text-gray-500">
             Edit Event
           </h1>
@@ -172,7 +172,7 @@ export default function EditView({
                 Title
               </label>
               <input
-                className="h-16 w-full rounded-md border px-4 pt-6 text-gray-800"
+                className="h-16 w-full rounded-md border px-4 pt-6 text-sm text-gray-800 sm:text-base"
                 type="text"
                 id="title"
                 placeholder={event.title}
@@ -196,7 +196,7 @@ export default function EditView({
                 Description
               </label>
               <textarea
-                className="h-32 w-full rounded-md border px-4 pt-8 text-gray-800"
+                className="h-32 w-full rounded-md border px-4 pt-8 text-sm text-gray-800 sm:text-base"
                 id="description"
                 placeholder={event.description as string}
                 maxLength={descMaxLength}
@@ -207,7 +207,7 @@ export default function EditView({
                 value={tempDesc}
                 onChange={(ev) => setTempDesc(ev.target.value)}
               />
-              <p className="absolute bottom-3 right-3 text-sm text-gray-500">
+              <p className="absolute bottom-3 right-3 rounded-full p-1 text-sm text-gray-500 backdrop-blur-sm">
                 {descMaxLength - (tempDesc ? tempDesc.length : 0)} characters
                 left
               </p>
@@ -221,7 +221,7 @@ export default function EditView({
                 Location
               </label>
               <input
-                className="h-16 w-full rounded-md border px-4 pt-6 text-gray-800"
+                className="h-16 w-full rounded-md border px-4 pt-6 text-sm text-gray-800 sm:text-base"
                 type="text"
                 id="location"
                 placeholder={event.location}
@@ -238,15 +238,16 @@ export default function EditView({
             </div>
 
             <div className="flex w-full space-x-2">
-              <div className="relative w-1/2">
+              <div className="relative w-1/3">
                 <label
                   htmlFor="access-date"
                   className="absolute left-4 top-3 text-xs font-bold uppercase text-gray-600"
                 >
-                  Access Date
+                  <p className="hidden sm:block">Access Date</p>
+                  <p className="block sm:hidden">Date</p>
                 </label>
                 <input
-                  className="h-16 w-full cursor-pointer rounded-md border px-3 pt-6 text-gray-600"
+                  className="h-16 w-full cursor-pointer rounded-md border px-3 pt-6 text-sm text-gray-600 sm:text-base"
                   type="date"
                   id="access-date"
                   value={tempAccessDate}
@@ -254,15 +255,16 @@ export default function EditView({
                   onChange={(ev) => setTempAccessDate(ev.target.value)}
                 />
               </div>
-              <div className="relative w-1/2">
+              <div className="relative w-1/3">
                 <label
                   htmlFor="access-start"
                   className="absolute left-4 top-3 text-xs font-bold uppercase text-gray-600"
                 >
-                  Access Starts
+                  <p className="hidden sm:block">Access Starts</p>
+                  <p className="block sm:hidden">Starts</p>
                 </label>
                 <input
-                  className="h-16 w-full cursor-pointer rounded-md border px-3 pt-6 text-gray-600"
+                  className="h-16 w-full cursor-pointer rounded-md border px-3 pt-6 text-sm text-gray-600 sm:text-base"
                   type="time"
                   id="access-start"
                   value={tempAccessStart}
@@ -270,15 +272,16 @@ export default function EditView({
                   onChange={(ev) => setTempAccessStart(ev.target.value)}
                 />
               </div>
-              <div className="relative w-1/2">
+              <div className="relative w-1/3">
                 <label
                   htmlFor="access-end"
                   className="absolute left-4 top-3 text-xs font-bold uppercase text-gray-600"
                 >
-                  Access Expires
+                  <p className="hidden sm:block">Access Expires</p>
+                  <p className="block sm:hidden">Expires</p>
                 </label>
                 <input
-                  className="h-16 w-full cursor-pointer rounded-md border px-3 pt-6 text-gray-800"
+                  className="h-16 w-full cursor-pointer rounded-md border px-3 pt-6 text-sm text-gray-800 sm:text-base"
                   type="time"
                   id="access-end"
                   value={tempAccessEnd}

--- a/components/Event/EventModal/InfoView.tsx
+++ b/components/Event/EventModal/InfoView.tsx
@@ -24,41 +24,45 @@ export default function InfoView({
 
   return (
     <>
-      <div className="px-7 py-6">
+      <div className="p-4 sm:px-7 sm:py-6">
         <div className="pb-4">
-          <h1 className="text-2xl font-medium">{event.title}</h1>
-          <p className="text-gray-500">{event.description}</p>
+          <h1 className="text-xl font-medium sm:text-2xl">{event.title}</h1>
+          <p className="text-sm text-gray-500 sm:text-base">
+            {event.description}
+          </p>
         </div>
-        <ul className="divide-y py-10">
-          <li className="flex py-1.5">
-            <p className="w-1/5 text-sm font-semibold uppercase text-gray-500">
+        <ul className="divide-y py-5 sm:py-10">
+          <li className="py-1.5 sm:flex">
+            <p className="pb-1.5 text-xs font-semibold uppercase text-gray-500 sm:w-1/5 sm:pb-0 sm:text-sm">
               Location
             </p>
-            <p className="w-4/5 text-gray-800">{event.location}</p>
+            <p className="text-sm text-gray-800 sm:w-4/5 sm:text-base">
+              {event.location}
+            </p>
           </li>
-          <li className="flex py-1.5">
-            <p className="w-1/5 text-sm font-semibold uppercase text-gray-500">
+          <li className="py-1.5 sm:flex">
+            <p className="pb-1.5 text-xs font-semibold uppercase text-gray-500 sm:w-1/5 sm:pb-0 sm:text-sm">
               Created
             </p>
-            <p className="w-4/5 text-gray-800">
+            <p className="text-sm text-gray-800 sm:w-4/5 sm:text-base">
               {getDateTime(new Date(event.createdAt))}
             </p>
           </li>
-          <li className="flex py-1.5">
-            <p className="w-1/5 text-sm font-semibold uppercase text-gray-500">
+          <li className="py-1.5 sm:flex">
+            <p className="pb-1.5 text-xs font-semibold uppercase text-gray-500 sm:w-1/5 sm:pb-0 sm:text-sm">
               Access
             </p>
-            <p className="w-4/5 text-gray-800">
+            <p className="text-sm text-gray-800 sm:w-4/5 sm:text-base">
               {getDateTime(new Date(event.accessStart))} {' - '}
               {getDateTime(new Date(event.accessEnd))}
             </p>
           </li>
-          <li className="flex py-1.5">
-            <p className="w-1/5 text-sm font-semibold uppercase text-gray-500">
+          <li className="py-1.5 sm:flex">
+            <p className="pb-1.5 text-xs font-semibold uppercase text-gray-500 sm:w-1/5 sm:pb-0 sm:text-sm">
               Verifier code
             </p>
 
-            <div className="flex w-4/5 space-x-2.5">
+            <div className="flex space-x-2.5 text-sm sm:w-4/5 sm:text-base">
               <button
                 className="rounded-full bg-gray-200 p-0.5 transition-colors duration-150 hover:bg-gray-300"
                 onClick={() => setVerifierCodeIsVisible(!verifierCodeIsVisible)}
@@ -79,11 +83,11 @@ export default function InfoView({
               </div>
             </div>
           </li>
-          <li className="flex py-1.5">
-            <p className="w-1/5 text-sm font-semibold uppercase text-gray-500">
+          <li className="py-1.5 sm:flex">
+            <p className="pb-1.5 text-xs font-semibold uppercase text-gray-500 sm:w-1/5 sm:pb-0 sm:text-sm">
               Invite link
             </p>
-            <div className="w-4/5 text-blue-600 transition-colors duration-200 hover:text-blue-400">
+            <div className="flex break-all text-sm text-blue-600 transition-colors duration-200 hover:text-blue-400 sm:w-4/5 sm:text-base">
               <button
                 onClick={() => {
                   router.push(event?.inviteLink)
@@ -111,17 +115,17 @@ export default function InfoView({
           </div>
         </div>
         {displayInvites.length > 0 && (
-          <div className="max-h-48 overflow-y-auto rounded-lg bg-gray-100 px-4 py-2">
+          <div className="max-h-48 overflow-y-auto rounded-lg bg-gray-100 px-1.5 py-2 sm:px-4">
             <table className="w-full">
               <thead>
                 <tr>
-                  <th className="sticky top-0 rounded-l-lg bg-gray-300 bg-opacity-60 pl-3 text-sm font-semibold uppercase text-gray-600 backdrop-blur-lg">
+                  <th className="sticky top-0 rounded-l-lg bg-gray-300 bg-opacity-60 pl-1.5 text-xs font-semibold uppercase text-gray-600 backdrop-blur-lg sm:pl-3 sm:text-sm">
                     Name
                   </th>
-                  <th className="sticky top-0 bg-gray-300 bg-opacity-60 text-sm font-semibold uppercase text-gray-600 backdrop-blur-lg">
+                  <th className="sticky top-0 hidden bg-gray-300 bg-opacity-60 text-xs font-semibold uppercase text-gray-600 backdrop-blur-lg sm:block sm:text-sm">
                     Email
                   </th>
-                  <th className="sticky top-0 rounded-r-lg bg-gray-300 bg-opacity-60 pr-3 text-right text-sm font-semibold uppercase text-gray-600 backdrop-blur-lg">
+                  <th className="sticky top-0 rounded-r-lg bg-gray-300 bg-opacity-60 pr-1.5 text-right text-xs font-semibold uppercase text-gray-600 backdrop-blur-lg sm:pr-3 sm:text-sm">
                     Accepted
                   </th>
                 </tr>
@@ -133,13 +137,13 @@ export default function InfoView({
                     onClick={() => onClickInvite(inv, index)}
                     className="cursor-pointer transition-colors duration-150 hover:bg-gray-200"
                   >
-                    <td className="whitespace-normal rounded-l-lg py-1.5 pl-3 text-gray-800">
+                    <td className="whitespace-normal rounded-l-lg py-2.5 pl-1.5 text-sm text-gray-800 sm:py-1.5 sm:pl-3 sm:text-base">
                       {inv.firstName} {inv.lastName}
                     </td>
-                    <td className="whitespace-nowrap py-1.5 text-gray-800">
+                    <td className="hidden whitespace-normal py-2.5 text-sm text-gray-800 sm:block sm:whitespace-nowrap sm:py-1.5 sm:text-base">
                       {inv.email}
                     </td>
-                    <td className="whitespace-nowrap rounded-r-lg py-1.5 pr-3 text-right text-gray-800">
+                    <td className="whitespace-normal rounded-r-lg py-2.5 pr-1.5 text-right text-sm text-gray-800 sm:whitespace-nowrap sm:py-1.5 sm:pr-3 sm:text-base">
                       {getDateTime(new Date(inv.acceptedAt))}
                     </td>
                   </tr>

--- a/components/Event/EventModal/InviteView.tsx
+++ b/components/Event/EventModal/InviteView.tsx
@@ -54,25 +54,25 @@ export default function InviteView({
 
   return (
     <>
-      <div className="px-7 py-6">
+      <div className="p-4 sm:px-7 sm:py-6">
         <div className="pb-8">
-          <h1 className="text-2xl font-medium">
+          <h1 className="text-xl font-medium sm:text-2xl">
             {invite?.firstName} {invite?.lastName}
           </h1>
-          <p className="text-gray-500">
+          <p className="text-sm text-gray-500 sm:text-base">
             {invite?.scannedAt
               ? `Ticket scanned ${getDateTime(new Date(invite.scannedAt))}`
               : 'Ticket not yet scanned'}
           </p>
         </div>
-        <ul>
-          <li className="flex">
+        <ul className="flex flex-col space-y-2 sm:space-y-0">
+          <li className="sm:flex">
             <p className="w-1/5 text-sm font-semibold uppercase text-gray-500">
               Email
             </p>
             <p className="w-4/5 text-gray-800">{invite?.email}</p>
           </li>
-          <li className="flex">
+          <li className="sm:flex">
             <p className="w-1/5 text-sm font-semibold uppercase text-gray-500">
               Accepted
             </p>

--- a/components/Event/EventRow.tsx
+++ b/components/Event/EventRow.tsx
@@ -28,7 +28,7 @@ export default function EventRow({
         onMouseEnter={() => setIsHovering(true)}
         onMouseLeave={() => setIsHovering(false)}
       >
-        <td className="whitespace-nowrap text-gray-800">
+        <td className="text-xs text-gray-800 sm:whitespace-nowrap sm:text-sm">
           <div
             className={classNames(
               'mt-2 h-[4.2rem] cursor-pointer font-semibold',
@@ -37,21 +37,21 @@ export default function EventRow({
                 : 'bg-white'
             )}
           >
-            <div className="relative flex h-full place-items-center justify-start pl-10">
+            <div className="relative flex h-full place-items-center justify-start pl-4 sm:pl-10">
               {new Date(event.accessStart) <= today &&
                 today <= new Date(event.accessEnd) && (
-                  <>
+                  <div className="hidden sm:block">
                     <div className="absolute left-5 flex place-items-center justify-center">
                       <div className="absolute h-3 w-3 animate-ping rounded-full bg-green-300" />
                       <div className="absolute h-2 w-2 rounded-full bg-green-300" />
                     </div>
-                  </>
+                  </div>
                 )}
               {event.title}
             </div>
           </div>
         </td>
-        <td className="whitespace-nowrap text-center text-gray-800">
+        <td className="text-center text-xs text-gray-800 sm:whitespace-nowrap sm:text-sm">
           <div
             className={classNames(
               'mt-2 h-[4.2rem]',
@@ -65,7 +65,7 @@ export default function EventRow({
             </p>
           </div>
         </td>
-        <td className="whitespace-nowrap text-center text-gray-800">
+        <td className="text-center text-xs text-gray-800 sm:whitespace-nowrap sm:text-sm">
           <div
             className={classNames(
               'mt-2 h-[4.2rem]',
@@ -74,13 +74,13 @@ export default function EventRow({
                 : 'bg-white'
             )}
           >
-            <div className="flex h-full flex-col place-items-center justify-center">
+            <div className="flex h-full flex-col justify-center pr-4 text-right sm:place-items-center sm:pr-0 sm:text-center">
               <p>{getDateTime(new Date(event.accessStart))}</p>
               <p>{getDateTime(new Date(event.accessEnd))}</p>
             </div>
           </div>
         </td>
-        <td className="whitespace-nowrap text-right text-gray-800">
+        <td className="hidden text-right text-gray-800 sm:block sm:whitespace-nowrap">
           <div
             className={classNames(
               'mt-2 h-[4.2rem]',

--- a/components/Event/EventTable.tsx
+++ b/components/Event/EventTable.tsx
@@ -19,16 +19,16 @@ export default function EventTable({
           <table className="w-full" cellPadding={0}>
             <thead>
               <tr className="bg-gray-200">
-                <th className="sticky top-0 py-5 pl-10 text-left text-xs font-semibold uppercase text-gray-500 text-opacity-80">
+                <th className="sticky top-0 py-5 pl-4 text-left text-xs font-semibold uppercase text-gray-500 text-opacity-80 sm:pl-10">
                   Title
                 </th>
                 <th className="sticky top-0 py-5 text-center text-xs font-semibold uppercase text-gray-500 text-opacity-80">
                   Location
                 </th>
-                <th className="sticky top-0 py-5 text-center text-xs font-semibold uppercase text-gray-500 text-opacity-80">
+                <th className="sticky top-0 py-5 pr-4 text-right text-xs font-semibold uppercase text-gray-500 text-opacity-80 sm:pr-0 sm:text-center">
                   Access
                 </th>
-                <th className="sticky top-0 py-5 pr-10 text-right text-xs font-semibold uppercase text-gray-500 text-opacity-80">
+                <th className="sticky top-0 hidden py-5 pr-4 text-right text-xs font-semibold uppercase text-gray-500 text-opacity-80 sm:block sm:pr-10">
                   Status
                 </th>
               </tr>
@@ -68,7 +68,7 @@ export default function EventTable({
                       </div>
                     </td>
                     <td>
-                      <div className="mt-2 h-[4.2rem] bg-white">
+                      <div className="mt-2 hidden h-[4.2rem] bg-white sm:block">
                         <div className="flex h-full place-items-center">
                           <div className="mx-2 h-1/3 w-full animate-pulse rounded-full bg-gray-300 bg-opacity-50" />
                         </div>

--- a/components/Event/EventTable.tsx
+++ b/components/Event/EventTable.tsx
@@ -7,15 +7,17 @@ export default function EventTable({
   events,
   eventsAreLoading,
   reload,
+  rows,
 }: {
   events: Event[]
   eventsAreLoading: boolean
   reload: () => void
+  rows: number
 }) {
   return (
     <>
       <div className="py-4">
-        <div className="min-h-[28.5rem] w-full overflow-auto">
+        <div className="min-h-[18rem] w-full overflow-auto sm:min-h-[27.5rem]">
           <table className="w-full" cellPadding={0}>
             <thead>
               <tr className="bg-gray-200">
@@ -44,7 +46,7 @@ export default function EventTable({
                   />
                 ))}
               {eventsAreLoading &&
-                [1, 2, 3, 4, 5].map((row: number, index: number) => (
+                new Array(rows).fill(1).map((row: number, index: number) => (
                   <tr key={index} className="drop-shadow-md">
                     <td>
                       <div className="mt-2 h-[4.2rem] bg-white">

--- a/components/Event/EventTableTabs.tsx
+++ b/components/Event/EventTableTabs.tsx
@@ -64,16 +64,20 @@ export default function EventTableTabs({
       {tableTabs.map((tab: TableTab, index: number) => (
         <div
           className={classNames(
-            'flex h-full w-24 cursor-pointer place-items-center justify-center space-x-1 font-medium hover:font-semibold',
+            'flex h-full w-24 cursor-pointer place-items-center justify-center space-x-1 pb-4 font-medium hover:font-semibold sm:pb-0',
             tab.isActive
               ? 'border-b-2 border-b-sage-200 text-sage-200'
               : 'text-gray-600',
-            index === 0 ? 'ml-4' : index === tableTabs.length - 1 ? 'mr-4' : ''
+            index === 0
+              ? 'sm:ml-4'
+              : index === tableTabs.length - 1
+              ? 'sm:mr-4'
+              : ''
           )}
           key={index}
           onClick={() => handleTabClick(tab, index)}
         >
-          <tab.icon className="h-5 w-5" />
+          <tab.icon className="hidden h-5 w-5 sm:block" />
           <p>{tab.title}</p>
         </div>
       ))}

--- a/components/Header/DashboardHeader.tsx
+++ b/components/Header/DashboardHeader.tsx
@@ -4,19 +4,25 @@ import ToggleTheme from './ToggleTheme'
 import NotificationBell from './NotificationBell'
 import { UserButton } from '@clerk/nextjs'
 import { useRouter } from 'next/navigation'
+import SidebarButton from '../Sidebar/SidebarButton'
 
 export default function DashboardHeader() {
   const router = useRouter()
 
   return (
-    <div className="grid h-16 w-full grid-cols-12 justify-between bg-white shadow-sm">
-      <div className="col-span-3 flex place-items-center justify-center">
-        <h1 className="text-2xl font-medium">
-          <button onClick={() => router.push('/')}>gatekeeper</button>
+    <div className="flex h-16 w-full justify-between bg-white px-5 shadow-sm sm:grid sm:grid-cols-12">
+      <div className="flex place-items-center justify-center sm:col-span-3">
+        <h1 className="text-xl font-medium sm:text-2xl">
+          <button className="hidden sm:block" onClick={() => router.push('/')}>
+            gatekeeper
+          </button>
+          <div className="block sm:hidden">
+            <SidebarButton>gatekeeper</SidebarButton>
+          </div>
         </h1>
       </div>
 
-      <div className="col-span-9 flex place-items-center justify-end space-x-5 pr-10">
+      <div className="flex place-items-center justify-end space-x-3 sm:col-span-9 sm:space-x-5 sm:pr-10">
         {/* dark/light mode */}
         <ToggleTheme />
 
@@ -24,7 +30,9 @@ export default function DashboardHeader() {
         <NotificationBell />
 
         {/* user profile */}
-        <UserButton afterSignOutUrl="/" showName={true} />
+        <div className="pl-1.5 sm:pl-0">
+          <UserButton afterSignOutUrl="/" showName={false} />
+        </div>
       </div>
     </div>
   )

--- a/components/Header/DashboardHeader.tsx
+++ b/components/Header/DashboardHeader.tsx
@@ -5,19 +5,35 @@ import NotificationBell from './NotificationBell'
 import { UserButton } from '@clerk/nextjs'
 import { useRouter } from 'next/navigation'
 import SidebarButton from '../Sidebar/SidebarButton'
+import {
+  ArrowLeftOnRectangleIcon,
+  ArrowRightOnRectangleIcon,
+} from '@heroicons/react/24/outline'
+import { useState } from 'react'
 
 export default function DashboardHeader() {
   const router = useRouter()
+  const [sidebarIsOpen, setSidebarIsOpen] = useState(false)
 
   return (
-    <div className="flex h-16 w-full justify-between bg-white px-5 shadow-sm sm:grid sm:grid-cols-12">
+    <div className="flex h-16 w-full justify-between bg-white px-5 shadow-sm sm:grid sm:grid-cols-12 sm:px-0">
       <div className="flex place-items-center justify-center sm:col-span-3">
         <h1 className="text-xl font-medium sm:text-2xl">
           <button className="hidden sm:block" onClick={() => router.push('/')}>
             gatekeeper
           </button>
           <div className="block sm:hidden">
-            <SidebarButton>gatekeeper</SidebarButton>
+            <SidebarButton isOpen={sidebarIsOpen} setIsOpen={setSidebarIsOpen}>
+              <div className="flex place-items-center space-x-1">
+                <p>gatekeeper</p>
+                {!sidebarIsOpen && (
+                  <ArrowRightOnRectangleIcon className="h-6 w-6 text-gray-600" />
+                )}
+                {sidebarIsOpen && (
+                  <ArrowLeftOnRectangleIcon className="h-6 w-6 text-gray-600" />
+                )}
+              </div>
+            </SidebarButton>
           </div>
         </h1>
       </div>

--- a/components/Header/GuestHeader.tsx
+++ b/components/Header/GuestHeader.tsx
@@ -10,17 +10,19 @@ export default function DashboardHeader() {
   return (
     <div className="relative flex h-16 w-full justify-between bg-white px-5 shadow-sm sm:grid sm:grid-cols-12 sm:px-0">
       <div className="flex h-full place-items-center justify-center sm:col-span-3">
-        <h1 className="text-2xl font-medium">
+        <h1 className="text-xl font-medium sm:text-2xl">
           <button onClick={() => router.push('/')}>gatekeeper</button>
         </h1>
       </div>
 
-      <div className="flex place-items-center justify-end sm:col-span-9 sm:space-x-5 sm:pr-10">
+      <div className="flex place-items-center justify-end space-x-3 sm:col-span-9 sm:space-x-5 sm:pr-10">
         {/* dark/light mode */}
         <ToggleTheme />
 
         {/* user profile */}
-        <UserButton afterSignOutUrl="/" showName={true} />
+        <div className="pl-1.5 sm:pl-0">
+          <UserButton afterSignOutUrl="/" showName={false} />
+        </div>
       </div>
     </div>
   )

--- a/components/Invite/InviteForm.tsx
+++ b/components/Invite/InviteForm.tsx
@@ -80,12 +80,12 @@ export default function InviteForm({ eventId }: { eventId: string }) {
   return (
     <>
       {!qrSrc && (
-        <div className="relative mt-10 flex h-3/5 place-items-center justify-center">
+        <div className="relative mt-16 flex h-3/5 place-items-center justify-center sm:mt-10">
           <div className="w-full rounded-xl bg-white p-3 shadow-md sm:w-1/2 sm:p-10">
             <div className="pb-6">
               <p className="pb-4 text-center text-sm text-gray-500 sm:text-base">
                 You are invited! Fill out the information to receive your QR
-                code. Keep this handy for getting access to the event.
+                code. You will need it in order to get access into the event.
               </p>
               <hr />
               <h1 className="pt-6 text-center text-xl font-medium text-gray-700 sm:text-2xl">
@@ -132,8 +132,8 @@ export default function InviteForm({ eventId }: { eventId: string }) {
                 />
               </div>
 
-              <div className="flex space-x-2">
-                <div className="relative w-1/2">
+              <div className="space-y-2 sm:flex sm:space-x-2 sm:space-y-0">
+                <div className="relative sm:w-1/2">
                   <label
                     htmlFor="first-name"
                     className="absolute left-4 top-3 text-xs font-bold uppercase text-gray-600"
@@ -155,7 +155,7 @@ export default function InviteForm({ eventId }: { eventId: string }) {
                   />
                 </div>
 
-                <div className="relative w-1/2">
+                <div className="relative sm:w-1/2">
                   <label
                     htmlFor="last-name"
                     className="absolute left-4 top-3 text-xs font-bold uppercase text-gray-600"

--- a/components/Invite/InviteForm.tsx
+++ b/components/Invite/InviteForm.tsx
@@ -81,21 +81,23 @@ export default function InviteForm({ eventId }: { eventId: string }) {
     <>
       {!qrSrc && (
         <div className="relative mt-10 flex h-3/5 place-items-center justify-center">
-          <div className="w-1/2 rounded-xl bg-white p-10 shadow-md">
+          <div className="w-full rounded-xl bg-white p-3 shadow-md sm:w-1/2 sm:p-10">
             <div className="pb-6">
-              <p className="pb-4 text-center text-gray-500">
+              <p className="pb-4 text-center text-sm text-gray-500 sm:text-base">
                 You are invited! Fill out the information to receive your QR
                 code. Keep this handy for getting access to the event.
               </p>
               <hr />
-              <h1 className="pt-6 text-center text-2xl font-medium text-gray-700">
+              <h1 className="pt-6 text-center text-xl font-medium text-gray-700 sm:text-2xl">
                 {event?.title}
               </h1>
-              <p className="pb-6 text-center text-gray-500">
+              <p className="pb-6 text-center text-sm text-gray-500 sm:text-base">
                 {event?.description}
               </p>
-              <p className="text-center text-gray-500">{event?.location}</p>
-              <p className="text-center text-gray-500">
+              <p className="text-center text-sm text-gray-500 sm:text-base">
+                {event?.location}
+              </p>
+              <p className="text-center text-sm text-gray-500 sm:text-base">
                 {`${getDateTime(
                   new Date(event?.accessStart as Date)
                 )} - ${getDateTime(new Date(event?.accessEnd as Date))}`}
@@ -116,7 +118,7 @@ export default function InviteForm({ eventId }: { eventId: string }) {
                   Email
                 </label>
                 <input
-                  className="h-16 w-full rounded-md border px-4 pt-6 text-gray-800"
+                  className="h-16 w-full rounded-md border px-4 pt-6 text-sm text-gray-800 sm:text-base"
                   type="text"
                   id="email"
                   placeholder="janedoe@gmail.com"
@@ -139,7 +141,7 @@ export default function InviteForm({ eventId }: { eventId: string }) {
                     First name
                   </label>
                   <input
-                    className="h-16 w-full rounded-md border px-4 pt-6 text-gray-800"
+                    className="h-16 w-full rounded-md border px-4 pt-6 text-sm text-gray-800 sm:text-base"
                     type="text"
                     id="first-name"
                     placeholder="Jane"
@@ -161,7 +163,7 @@ export default function InviteForm({ eventId }: { eventId: string }) {
                     Last name
                   </label>
                   <input
-                    className="h-16 w-full rounded-md border px-4 pt-6 text-gray-800"
+                    className="h-16 w-full rounded-md border px-4 pt-6 text-sm text-gray-800 sm:text-base"
                     type="text"
                     id="last-name"
                     placeholder="Doe"
@@ -195,7 +197,7 @@ export default function InviteForm({ eventId }: { eventId: string }) {
               {qrSrc && <img src={qrSrc} alt="qr" />}
             </div>
           </div>
-          <div className="flex justify-center space-x-1 pt-5">
+          <div className="space-x-1 pt-5 text-center sm:flex sm:justify-center">
             <p className="text-gray-600">Email with QR code sent to</p>
             <p className="font-medium text-gray-700">{tempEmail}</p>
           </div>

--- a/components/Modal.tsx
+++ b/components/Modal.tsx
@@ -6,7 +6,7 @@ import classNames from '@/lib/classNames'
 export default function Modal({
   isOpen,
   onClose,
-  width = 'sm:max-w-3xl max-w-xs',
+  width = 'sm:max-w-3xl max-w-full mx-3 sm:mx-0',
   children,
 }: {
   isOpen: boolean

--- a/components/PageWrapper.tsx
+++ b/components/PageWrapper.tsx
@@ -9,17 +9,17 @@ export default function PageWrapper({
 }) {
   return (
     <div className="h-screen">
-      <div className="pb-8">
+      <div className="pb-5 sm:pb-8">
         {/* title */}
         <div>
-          <h1 className="text-2xl font-medium text-gray-600 sm:text-3xl">
+          <h1 className="text-lg font-medium text-gray-600 sm:text-3xl">
             {title}
           </h1>
         </div>
 
         {/* description */}
         <div>
-          <p className="w-2/3 text-sm font-normal text-gray-400 sm:w-1/2 sm:text-base">
+          <p className="w-2/3 text-xs font-normal text-gray-400 sm:w-1/2 sm:text-base">
             {description}
           </p>
         </div>

--- a/components/PageWrapper.tsx
+++ b/components/PageWrapper.tsx
@@ -12,12 +12,16 @@ export default function PageWrapper({
       <div className="pb-8">
         {/* title */}
         <div>
-          <h1 className="text-3xl font-medium text-gray-600">{title}</h1>
+          <h1 className="text-2xl font-medium text-gray-600 sm:text-3xl">
+            {title}
+          </h1>
         </div>
 
         {/* description */}
         <div>
-          <p className="w-1/2 font-normal text-gray-400">{description}</p>
+          <p className="w-2/3 text-sm font-normal text-gray-400 sm:w-1/2 sm:text-base">
+            {description}
+          </p>
         </div>
       </div>
 

--- a/components/PageWrapper.tsx
+++ b/components/PageWrapper.tsx
@@ -8,7 +8,7 @@ export default function PageWrapper({
   children: React.ReactNode
 }) {
   return (
-    <>
+    <div className="h-screen">
       <div className="pb-8">
         {/* title */}
         <div>
@@ -27,6 +27,6 @@ export default function PageWrapper({
 
       {/* content */}
       <div>{children}</div>
-    </>
+    </div>
   )
 }

--- a/components/Sidebar/Sidebar.tsx
+++ b/components/Sidebar/Sidebar.tsx
@@ -60,15 +60,16 @@ export default function Sidebar() {
 
   return (
     <div className="h-full border-[1px]">
-      {/* app title */}
-      <div className="h-16">
-        <h1 className="flex h-full place-items-center justify-center text-3xl font-semibold">
-          gatekeeper
-        </h1>
-      </div>
-
       {/* tabs */}
-      <div className="divide-y divide-gray-200 px-10 pt-6">
+      <div className="block px-4 pb-4 pt-4 sm:hidden">
+        <div
+          className="flex justify-center rounded-xl border-[1px] py-2 text-sm font-medium text-gray-500 shadow-sm transition-colors duration-150 hover:bg-gray-100"
+          onClick={() => router.push('/')}
+        >
+          Back to home
+        </div>
+      </div>
+      <div className="divide-y divide-gray-200 px-4 pt-4 sm:px-10 sm:pt-[5.5rem]">
         <ul className="pb-4">
           {primaryTabs.map((tab: SidebarTab, index: number) => (
             <li className="py-1" key={index} onClick={() => routeToTab(tab)}>

--- a/components/Sidebar/Sidebar.tsx
+++ b/components/Sidebar/Sidebar.tsx
@@ -11,7 +11,7 @@ import {
 } from '@heroicons/react/24/outline'
 import { useRouter, usePathname } from 'next/navigation'
 
-export default function Sidebar() {
+export default function Sidebar({ onRoute }: { onRoute?: () => void }) {
   interface SidebarTab {
     icon: any
     title: string
@@ -55,6 +55,7 @@ export default function Sidebar() {
   function routeToTab(tab: SidebarTab) {
     if (!pathname.includes(tab.route)) {
       router.push(tab.route)
+      if (onRoute) onRoute()
     }
   }
 

--- a/components/Sidebar/SidebarButton.tsx
+++ b/components/Sidebar/SidebarButton.tsx
@@ -1,0 +1,27 @@
+import { useState } from 'react'
+import classNames from '@/lib/classNames'
+import Sidebar from './Sidebar'
+
+export default function SidebarButton({
+  children,
+}: {
+  children: React.ReactNode
+}) {
+  const [isOpen, setIsOpen] = useState(true)
+
+  return (
+    <>
+      <button onClick={() => setIsOpen(!isOpen)}>{children}</button>
+
+      <div
+        className={classNames(
+          isOpen ? 'translate-x-0' : '-translate-x-[30rem]',
+          'absolute left-0 z-30 h-screen w-2/3 transform bg-white pt-5 transition duration-700 ease-in-out'
+        )}
+      >
+        <Sidebar />
+        {/* test */}
+      </div>
+    </>
+  )
+}

--- a/components/Sidebar/SidebarButton.tsx
+++ b/components/Sidebar/SidebarButton.tsx
@@ -1,14 +1,16 @@
-import { useState } from 'react'
 import classNames from '@/lib/classNames'
 import Sidebar from './Sidebar'
+import { Dispatch, SetStateAction } from 'react'
 
 export default function SidebarButton({
+  isOpen,
+  setIsOpen,
   children,
 }: {
+  isOpen: boolean
+  setIsOpen: Dispatch<SetStateAction<boolean>>
   children: React.ReactNode
 }) {
-  const [isOpen, setIsOpen] = useState(true)
-
   return (
     <>
       <button onClick={() => setIsOpen(!isOpen)}>{children}</button>
@@ -19,8 +21,7 @@ export default function SidebarButton({
           'absolute left-0 z-30 h-screen w-2/3 transform bg-white pt-5 transition duration-700 ease-in-out'
         )}
       >
-        <Sidebar />
-        {/* test */}
+        <Sidebar onRoute={() => setIsOpen(false)} />
       </div>
     </>
   )

--- a/components/Sidebar/Tab.tsx
+++ b/components/Sidebar/Tab.tsx
@@ -13,7 +13,7 @@ export default function Tab({
   return (
     <div
       className={classNames(
-        'h-14 w-full cursor-pointer rounded-lg transition-colors duration-200',
+        'h-10 w-full cursor-pointer rounded-lg transition-colors duration-200 sm:h-14',
         isActive
           ? 'bg-sage-100 bg-opacity-40'
           : 'bg-white hover:bg-gray-200 hover:bg-opacity-70'
@@ -23,7 +23,7 @@ export default function Tab({
         <div className="pl-6">
           <Icon
             className={classNames(
-              'h-8 w-8',
+              'h-7 w-7 sm:h-8 sm:w-8',
               isActive ? 'text-sage-200' : 'text-gray-500'
             )}
           />
@@ -31,7 +31,7 @@ export default function Tab({
 
         <p
           className={classNames(
-            'pl-3 font-semibold',
+            'pl-3 text-lg font-medium sm:text-base sm:font-semibold',
             isActive ? 'text-sage-200' : 'text-gray-500'
           )}
         >


### PR DESCRIPTION
## Description
Add styling changes to `dashboard-group` pages, aimed at increasing the view-ability with _most_ mobile devices.

## Screenshot Samples
`my events`

<img width="150" alt="Screenshot 2023-12-23 at 3 19 47 AM" src="https://github.com/UNLV-CS-GANG/gatekeeper/assets/94032029/7afd2b5e-c2fa-4d43-8c86-de6562c69841">

<img width="150" alt="Screenshot 2023-12-23 at 3 22 50 AM" src="https://github.com/UNLV-CS-GANG/gatekeeper/assets/94032029/0f824913-5280-46a8-a1bc-fef47726db62">

`event modal views`

<img width="150" alt="Screenshot 2023-12-23 at 3 25 01 AM" src="https://github.com/UNLV-CS-GANG/gatekeeper/assets/94032029/d06c930e-628b-4e2d-9cb9-045f034c7d4a">

<img width="150" alt="Screenshot 2023-12-23 at 3 27 20 AM" src="https://github.com/UNLV-CS-GANG/gatekeeper/assets/94032029/f41a70e9-4296-4b62-afcd-1022361ef7e7">

<img width="150" alt="Screenshot 2023-12-23 at 3 28 52 AM" src="https://github.com/UNLV-CS-GANG/gatekeeper/assets/94032029/81e728c8-3142-49e0-a5e5-55e596dff26b">

<img width="150" alt="Screenshot 2023-12-23 at 3 29 27 AM" src="https://github.com/UNLV-CS-GANG/gatekeeper/assets/94032029/1cc4fe9c-f043-4a83-a689-9148d6e4164d">

`accept invite view`

<img width="150" alt="Screenshot 2023-12-23 at 3 38 06 AM" src="https://github.com/UNLV-CS-GANG/gatekeeper/assets/94032029/cd33c6dd-1098-444c-b34a-a88bf4a3656c">

## Note
Resolves #27